### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,5 @@ termcolor==1.1.0
 torch==1.1.0
 torchvision==0.3.0
 SimpleITK
+webcolors
+ants==0.1.4 (I don't know which is the correct version to work with ants; I'd to change some functions using this version, but I think it's the last one)


### PR DESCRIPTION
I've found some troubles executing the new version of PARIETAL, related to the ants version to use; the one I'm using it's the 0.1.4, even though I had to change two functions (image_read and to_filename), I don't know if there's a version where this changes aren't needed